### PR TITLE
fix: remove unused meeting folder setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,7 +182,6 @@ Access plugin settings via Settings → Nimble Task Notes:
 #### Calendar Settings
 - **ICS Subscription URL**: Your Outlook calendar ICS feed URL
 - **Refresh Interval**: How often to fetch calendar updates (default: 15 minutes)
-- **Meeting Folder**: Where to store meeting note files
 
 #### Task Settings
 - **Task Folder**: Where to create task files (default: `Tasks/`)

--- a/src/settings/SettingTab.ts
+++ b/src/settings/SettingTab.ts
@@ -39,19 +39,6 @@ export class LightweightTasksSettingTab extends PluginSettingTab {
 			);
 
 		new Setting(containerEl)
-			.setName("Meeting folder")
-			.setDesc("Folder where meeting notes will be created")
-			.addText((text) =>
-				text
-					.setPlaceholder("Meetings")
-					.setValue(this.plugin.settings.meetingFolder)
-					.onChange(async (value) => {
-						this.plugin.settings.meetingFolder = value;
-						await this.plugin.saveSettings();
-					}),
-			);
-
-		new Setting(containerEl)
 			.setName("Projects source folder")
 			.setDesc(
 				"Folder containing project files (leave empty for vault root)",

--- a/src/settings/defaults.ts
+++ b/src/settings/defaults.ts
@@ -2,7 +2,6 @@ import { LightweightTasksSettings } from "../types";
 
 export const DEFAULT_SETTINGS: LightweightTasksSettings = {
 	taskFolder: "Tasks",
-	meetingFolder: "Meetings",
 	calendarURL: "",
 	defaultTags: ["task"],
 	enableNaturalLanguageDates: true,

--- a/src/types.ts
+++ b/src/types.ts
@@ -94,9 +94,6 @@ export interface LightweightTasksSettings {
 	/** Folder path for task notes */
 	taskFolder: string;
 
-	/** Folder path for meeting notes */
-	meetingFolder: string;
-
 	/** Outlook calendar ICS feed URL */
 	calendarURL: string;
 


### PR DESCRIPTION
The meeting folder setting was unused since the plugin only imports meeting wikilinks into daily notes and never creates separate meeting files. Removed from:
- src/types.ts (interface definition)
- src/settings/defaults.ts (default value)
- src/settings/SettingTab.ts (settings UI)
- README.md (documentation)

Resolves #5